### PR TITLE
fix(downloader): поддержка Platform 8.5.x в onec-installer-downloader

### DIFF
--- a/src/onec-installer-downloader/downloader.sh
+++ b/src/onec-installer-downloader/downloader.sh
@@ -16,8 +16,11 @@ fi
 installer_type=$1
 ONEC_VERSION=$2
 
+platform_minor=$(echo "$ONEC_VERSION" | awk -F. '{print $1 "." $2}')
 if [ "$installer_type" = "edt" ]; then
     FOLDER_NAME="DevelopmentTools10"
+elif [ "$platform_minor" = "8.5" ]; then
+    FOLDER_NAME="Platform85"
 else
     FOLDER_NAME="Platform83"
 fi
@@ -172,7 +175,10 @@ check_file() {
 try_download() {
 
   # Определим фильтры для скачивания. Если шаблонов >1 они должны разделяться "|" Скачивается дистрибутив по первому найденному шаблону.
-  APP_FILTER="Технологическая платформа *8\.3"
+  case "$platform_minor" in
+    8.5) APP_FILTER="Технологическая платформа *8\.5" ;;
+    *)   APP_FILTER="Технологическая платформа *8\.3" ;;
+  esac
   case "$installer_type" in
     edt)
         echo "Скачиваем дистрибутив EDT"


### PR DESCRIPTION
### Summary

Добавлена поддержка скачивания дистрибутивов платформы **1С 8.5.x** через образ `onec-installer-downloader`.  
Релизы 8.5 на портале 1С лежат в каталоге **`Platform85`**, а не `Platform83` — без этого сборка `onec-platform:8.5.1.*` в `onec-images` падала при проверке скачанных файлов.

---

### Изменения для Platform 8.5

**Файл:** `src/onec-installer-downloader/downloader.sh`

| Было | Стало |
|------|--------|
| Всегда `FOLDER_NAME=Platform83` | `8.5.x` → `Platform85`, иначе `Platform83` |
| `APP_FILTER` только для `8.3` | Для `8.5` — `Технологическая платформа *8\.5` |

**Логика выбора каталога:**

```bash
platform_minor=$(echo "$ONEC_VERSION" | awk -F. '{print $1 "." $2}')
# 8.5.1.1302 → Platform85/8.5.1.1302
# 8.3.27.1644 → Platform83/8.3.27.1644
```

**Зачем:** `yard` сохраняет релизы 8.5 в `/tmp/downloads/Platform85/<версия>/`. Старый скрипт искал файлы в `Platform83` → `check_file` не находил `.deb` после успешного скачивания.

---

### Test plan

- [ ] Пересобрать `onec-installer-downloader` из `vendor`
- [ ] Локально / в CI: `downloader.sh server 8.5.1.1302` с `YARD_RELEASES_USER` / `YARD_RELEASES_PWD`
- [ ] Проверить путь: `/tmp/downloads/Platform85/8.5.1.1302/*.deb`
- [ ] Сборка `onec_platform_8.5.1.1302` в `onec-images` проходит стадию downloader
- [ ] Регрессия: `8.3.27.1644` по-прежнему использует `Platform83`

---

### Breaking changes

Нет для 8.3.x — поведение не меняется.

Для 8.5.x **обязателен** новый образ `onec-installer-downloader` в registry; старый `latest` без этого фикса не подходит.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшен выбор дистрибутива по версии платформы: для версии 8.5 теперь подбирается соответствующий вариант, а для остальных — стандартный.
  * Поиск загрузок стал точнее и лучше соответствует выбранной версии.
  * Исправлена ошибка в логике обработки сценария, когда локальные дистрибутивы не найдены и требуется загрузка.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->