### PR TITLE
feat(winow): add HEALTHCHECK for container monitoring

### DIFF
--- a/src/winow/Dockerfile
+++ b/src/winow/Dockerfile
@@ -18,6 +18,6 @@ VOLUME [ "/app" ]
 EXPOSE 3333
 
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
-  CMD curl -f http://localhost:3333/ || exit 1
+  CMD curl -f --show-error http://localhost:3333/ > /dev/null || exit 1
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/winow/Dockerfile
+++ b/src/winow/Dockerfile
@@ -6,11 +6,18 @@ ARG BASE_TAG=stable
 FROM ${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${BASE_IMAGE}:${BASE_TAG}
 LABEL maintainer="Iosif Pravets <i@pravets.ru>"
 
-RUN opm i opm winow winow-cli
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf \
+    && opm i opm winow winow-cli
 WORKDIR /app
 COPY ./src/winow/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 VOLUME [ "/app" ]
 EXPOSE 3333
+
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD curl -f http://localhost:3333/ || exit 1
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Adds Docker HEALTHCHECK to winow image so orchestrators can detect when the container is healthy.

## Changes

- Install `curl` in the build step (needed for HTTP health check)
- Add `HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD curl -f http://localhost:3333/ || exit 1`
- Clean apt cache after curl installation

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Улучшения**
  - Обновлён контейнер приложения: добавлены необходимые системные инструменты для корректной работы сервисов.
  - Добавлена автоматическая проверка доступности HTTP-сервиса, что позволяет быстрее выявлять проблемы при запуске и повышает надёжность работы приложения.
  - Очистка временных данных после установки помогает уменьшить размер контейнера.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->