### PR TITLE
CI: тестовая сборка образов в Pull Request по изменённым файлам

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,15 @@ jobs:
             echo "matrix=$json" >> "$GITHUB_OUTPUT"
           fi
 
-  prepare-base:
+  # Собирает базу oscript из кода PR, если она изменилась, и передаёт её
+  # build-джобам через artifact (джобы выполняются на изолированных раннерах,
+  # образы между ними не переживают). Всегда запускается — иначе outputs
+  # недоступны в build.
+  build-base:
     needs: detect
-    if: needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      base_ready: ${{ steps.build.outputs.base_ready }}
     env:
       CI: 'true'
       PUSH_IMAGE: 'false'
@@ -109,35 +114,35 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
         with:
-          driver: docker  # docker-container (по умолчанию) не видит локальные образы из демона
+          driver: docker  # docker-container не видит локальные образы из демона
 
-      - name: Prepare oscript base image
+      - name: Build oscript and yard from PR code
+        id: build
+        if: needs.detect.outputs.base_changed == 'true'
         run: |
           set -euo pipefail
-          if [[ '${{ needs.detect.outputs.base_changed }}' == 'true' ]]; then
-            # База изменилась — собираем из PR-кода; downstream соберётся поверх неё
-            export OSCRIPT_VERSION=stable
-            ./src/build-oscript.sh
-          else
-            # База не менялась — берём публичную и ретегаем под CI-имя
-            docker pull sleemp/oscript:stable
-            docker tag sleemp/oscript:stable ci/build/oscript:stable
-          fi
+          export OSCRIPT_VERSION=stable
+          ./src/build-oscript.sh
+          # yard нужен onec-installer-downloader'у как база — собираем и его
+          ./src/build-yard.sh
+          mkdir -p /tmp/base
+          docker save ci/build/oscript:stable ci/build/yard:latest | gzip > /tmp/base/base-images.tar.gz
+          echo 'base_ready=true' >> "$GITHUB_OUTPUT"
 
-      - name: Prepare yard base (нужна для onec-installer-downloader)
-        if: contains(needs.detect.outputs.matrix, '"oid"')
-        run: |
-          set -euo pipefail
-          if [[ '${{ needs.detect.outputs.base_changed }}' == 'true' ]]; then
-            # База менялась — yard уже собран на свежем oscript выше
-            ./src/build-yard.sh
-          else
-            docker pull sleemp/yard:latest
-            docker tag sleemp/yard:latest ci/build/yard:latest
-          fi
+      - name: Mark base as not changed
+        if: needs.detect.outputs.base_changed != 'true'
+        run: echo 'base_ready=false' >> "$GITHUB_OUTPUT"
+
+      - name: Upload base images
+        if: needs.detect.outputs.base_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-images
+          path: /tmp/base/base-images.tar.gz
+          retention-days: 1
 
   build:
-    needs: [detect, prepare-base]
+    needs: [detect, build-base]
     if: needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -152,7 +157,30 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
         with:
-          driver: docker  # docker-container (по умолчанию) не видит локальные образы из демона
+          driver: docker  # docker-container не видит локальные образы из демона
+
+      # Блок: не трогаем, если oscript в матрице — он собирает сам себя ниже
+      - name: Load PR-built base images
+        if: needs.build-base.outputs.base_ready == 'true' && matrix.image != 'oscript'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-images
+          path: /tmp/base
+
+      - name: Import base images into docker
+        if: needs.build-base.outputs.base_ready == 'true' && matrix.image != 'oscript'
+        run: docker load < /tmp/base/base-images.tar.gz
+
+      - name: Pull public base images
+        if: needs.build-base.outputs.base_ready != 'true'
+        run: |
+          set -euo pipefail
+          docker pull sleemp/oscript:stable
+          docker tag sleemp/oscript:stable ci/build/oscript:stable
+          if [[ '${{ matrix.image }}' == 'oid' ]]; then
+            docker pull sleemp/yard:latest
+            docker tag sleemp/yard:latest ci/build/yard:latest
+          fi
 
       - name: Build and test ${{ matrix.image }} (no push)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
       PUSH_IMAGE: 'false'
       DOCKER_REGISTRY_URL: 'ci'
       DOCKER_LOGIN: 'build'
+      ONEC_USERNAME: ${{ secrets.ONEC_USERNAME }}
+      ONEC_PASSWORD: ${{ secrets.ONEC_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -198,3 +200,32 @@ jobs:
               ./src/build-${{ matrix.image }}.sh
               ;;
           esac
+
+      # Реальная проверка скачивания дистрибутивов 1С через yard.
+      # Работает только если секреты доступны (не в форк-PR).
+      - name: Test distro downloads (8.3.27.2214, 8.5.1.1343, EDT 2026.1.2)
+        if: matrix.image == 'oid' && env.ONEC_USERNAME != ''
+        env:
+          YARD_RELEASES_USER: ${{ secrets.ONEC_USERNAME }}
+          YARD_RELEASES_PWD: ${{ secrets.ONEC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # server 8.3.27.2214
+          echo "=== Downloading 1C server 8.3.27.2214 ==="
+          docker run --rm \
+            -e YARD_RELEASES_USER="$YARD_RELEASES_USER" \
+            -e YARD_RELEASES_PWD="$YARD_RELEASES_PWD" \
+            -v /tmp/downloads:/tmp/downloads \
+            ci/build/onec-installer-downloader:ci-test server 8.3.27.2214
+          echo "=== Downloading 1C server 8.5.1.1343 ==="
+          docker run --rm \
+            -e YARD_RELEASES_USER="$YARD_RELEASES_USER" \
+            -e YARD_RELEASES_PWD="$YARD_RELEASES_PWD" \
+            -v /tmp/downloads:/tmp/downloads \
+            ci/build/onec-installer-downloader:ci-test server 8.5.1.1343
+          echo "=== Downloading EDT 2026.1.2 ==="
+          docker run --rm \
+            -e YARD_RELEASES_USER="$YARD_RELEASES_USER" \
+            -e YARD_RELEASES_PWD="$YARD_RELEASES_PWD" \
+            -v /tmp/downloads:/tmp/downloads \
+            ci/build/onec-installer-downloader:ci-test edt 2026.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker  # docker-container (по умолчанию) не видит локальные образы из демона
 
       - name: Prepare oscript base image
         run: |
@@ -149,6 +151,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker  # docker-container (по умолчанию) не видит локальные образы из демона
 
       - name: Build and test ${{ matrix.image }} (no push)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,168 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'tools/**'
+      - '.github/workflows/ci.yml'
+      - '!src/tag-*.sh'
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+      base_changed: ${{ steps.set-matrix.outputs.base_changed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            oscript:
+              - 'src/oscript/**'
+              - 'src/build-oscript.sh'
+              - 'tests/test-oscript.sh'
+            yard:
+              - 'src/yard/**'
+              - 'src/build-yard.sh'
+              - 'tests/test-yard.sh'
+            oid:
+              - 'src/onec-installer-downloader/**'
+              - 'src/build-onec-installer-downloader.sh'
+              - 'tests/test-onec-installer-downloader.sh'
+            winow:
+              - 'src/winow/**'
+              - 'src/build-winow.sh'
+              - 'tests/test-winow.sh'
+              - 'tests/winow/**'
+            gitrules:
+              - 'src/gitrules/**'
+              - 'src/build-gitrules.sh'
+              - 'tests/test-gitrules.sh'
+            stebi:
+              - 'src/stebi/**'
+              - 'src/build-stebi.sh'
+              - 'tests/test-stebi.sh'
+            edt-ripper:
+              - 'src/edt-ripper/**'
+              - 'src/build-edt-ripper.sh'
+              - 'tests/test-edt-ripper.sh'
+            common:
+              - 'scripts/**'
+              - 'tools/**'
+              - '.github/workflows/ci.yml'
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          images=()
+          all_images=(oscript yard oid winow gitrules stebi edt-ripper)
+
+          # Изменилась база oscript → собираем всё (регрессия downstream)
+          if [[ '${{ steps.changes.outputs.oscript }}' == 'true' ]]; then
+            images=("${all_images[@]}")
+            echo 'base_changed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'base_changed=false' >> "$GITHUB_OUTPUT"
+            [[ '${{ steps.changes.outputs.yard }}' == 'true' ]] && images+=(yard)
+            [[ '${{ steps.changes.outputs.oid }}' == 'true' ]] && images+=(oid)
+            [[ '${{ steps.changes.outputs.winow }}' == 'true' ]] && images+=(winow)
+            [[ '${{ steps.changes.outputs.gitrules }}' == 'true' ]] && images+=(gitrules)
+            [[ '${{ steps.changes.outputs.stebi }}' == 'true' ]] && images+=(stebi)
+            [[ '${{ steps.changes.outputs.edt-ripper }}' == 'true' ]] && images+=(edt-ripper)
+          fi
+
+          # Общая инфраструктура (scripts/tools/workflow) → всё
+          if [[ '${{ steps.changes.outputs.common }}' == 'true' ]]; then
+            images=("${all_images[@]}")
+          fi
+
+          if (( ${#images[@]} == 0 )); then
+            {
+              echo 'has_changes=false'
+              echo 'matrix={"image":[]}'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_changes=true' >> "$GITHUB_OUTPUT"
+            json="$(jq -cn --argjson arr "$(printf '%s\n' "${images[@]}" | jq -R . | jq -s .)" '{image: $arr}')"
+            echo "matrix=$json" >> "$GITHUB_OUTPUT"
+          fi
+
+  prepare-base:
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CI: 'true'
+      PUSH_IMAGE: 'false'
+      DOCKER_REGISTRY_URL: 'ci'
+      DOCKER_LOGIN: 'build'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Prepare oscript base image
+        run: |
+          set -euo pipefail
+          if [[ '${{ needs.detect.outputs.base_changed }}' == 'true' ]]; then
+            # База изменилась — собираем из PR-кода; downstream соберётся поверх неё
+            export OSCRIPT_VERSION=stable
+            ./src/build-oscript.sh
+          else
+            # База не менялась — берём публичную и ретегаем под CI-имя
+            docker pull sleemp/oscript:stable
+            docker tag sleemp/oscript:stable ci/build/oscript:stable
+          fi
+
+      - name: Prepare yard base (нужна для onec-installer-downloader)
+        if: contains(needs.detect.outputs.matrix, '"oid"')
+        run: |
+          set -euo pipefail
+          if [[ '${{ needs.detect.outputs.base_changed }}' == 'true' ]]; then
+            # База менялась — yard уже собран на свежем oscript выше
+            ./src/build-yard.sh
+          else
+            docker pull sleemp/yard:latest
+            docker tag sleemp/yard:latest ci/build/yard:latest
+          fi
+
+  build:
+    needs: [detect, prepare-base]
+    if: needs.detect.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    env:
+      CI: 'true'
+      PUSH_IMAGE: 'false'
+      DOCKER_REGISTRY_URL: 'ci'
+      DOCKER_LOGIN: 'build'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and test ${{ matrix.image }} (no push)
+        run: |
+          set -euo pipefail
+          case '${{ matrix.image }}' in
+            oscript)
+              export OSCRIPT_VERSION=stable
+              ./src/build-oscript.sh
+              ;;
+            oid)
+              export ONEC_INSTALLER_DOWNLOADER_VERSION=ci-test
+              ./src/build-onec-installer-downloader.sh
+              ;;
+            *)
+              ./src/build-${{ matrix.image }}.sh
+              ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # oscript-images
 
+![CI](https://github.com/pravets/oscript-images/actions/workflows/ci.yml/badge.svg)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/pravets/oscript-images?utm_source=oss&utm_medium=github&utm_campaign=pravets%2Foscript-images&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 ![License](https://img.shields.io/github/license/pravets/oscript-images)
 [![Telegram](https://telegram-badge.vercel.app/api/telegram-badge?channelId=@pravets_IT)](https://t.me/+GKGRmAwghxllYzIy)
@@ -17,6 +18,7 @@
 
 - [oscript-images](#oscript-images)
 - [Подготовительные шаги](#подготовительные-шаги)
+- [Проверка сборки в Pull Request](#проверка-сборки-в-pull-request)
 - [oscript](#oscript)
 - [yard](#yard)
 - [onec-installer-downloader](#onec-installer-downloader)
@@ -37,6 +39,32 @@
      - `DOCKER_REGISTRY_URL` — адрес реестра (например, `docker.io`)
      - `DOCKER_LOGIN` — ваш логин Docker Hub или в вашем приватном registry
      - `DOCKER_PASSWORD` — ваш пароль от вашего приватного registry или [токен Docker Hub](https://app.docker.com/settings/personal-access-tokens). Для Docker Hub нужны права Read и Write и рекомендуется использовать токен, вместо пароля.
+
+    [↑ В начало](#oscript-images)
+
+## Проверка сборки в Pull Request
+
+Каждый PR автоматически собирает и тестирует только те образы, чьи файлы изменились — без публикации в registry и без необходимости в секретах. Это позволяет ловить поломки сборки до мержа.
+
+| Изменённые файлы | Какие образы собираются |
+|---|---|
+| `src/oscript/**`, `src/build-oscript.sh`, `tests/test-oscript.sh` | **Все** (oscript — база, регрессия downstream обязательна) |
+| `src/yard/**`, `src/build-yard.sh`, `tests/test-yard.sh` | yard |
+| `src/onec-installer-downloader/**`, `src/build-onec-installer-downloader.sh`, `tests/test-onec-installer-downloader.sh` | onec-installer-downloader |
+| `src/winow/**`, `src/build-winow.sh`, `tests/test-winow.sh`, `tests/winow/**` | winow |
+| `src/gitrules/**`, `src/build-gitrules.sh`, `tests/test-gitrules.sh` | gitrules |
+| `src/stebi/**`, `src/build-stebi.sh`, `tests/test-stebi.sh` | stebi |
+| `src/edt-ripper/**`, `src/build-edt-ripper.sh`, `tests/test-edt-ripper.sh` | edt-ripper |
+| `scripts/**`, `tools/**`, `.github/workflows/ci.yml` | **Все** (общая инфраструктура) |
+| `README.md`, `LICENSE`, `src/tag-*.sh` | Ничего (workflow не запускается) |
+
+Если изменилась база `oscript`, она собирается из кода PR, и все downstream-образы пересобираются поверх неё. В остальных случаях база берётся из публичного registry (`sleemp/oscript:stable`), чтобы изолировать проверку именно изменённого образа.
+
+Для локального прогона без публикации используйте:
+
+```bash
+PUSH_IMAGE=false DOCKER_REGISTRY_URL=ci DOCKER_LOGIN=build OSCRIPT_VERSION=stable CI=true ./src/build-oscript.sh
+```
 
     [↑ В начало](#oscript-images)
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Разлогинивание из Docker
-if [ -n "$DOCKER_REGISTRY_URL" ]; then
-    docker logout "$DOCKER_REGISTRY_URL"
-else
-    docker logout
+# Разлогинивание из Docker (только если логинились — при PUSH_IMAGE=false логина не было)
+if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
+    if [ -n "${DOCKER_REGISTRY_URL:-}" ]; then
+        docker logout "$DOCKER_REGISTRY_URL"
+    else
+        docker logout
+    fi
 fi
 
 # Очистка переменных среды из .env

--- a/scripts/docker_login.sh
+++ b/scripts/docker_login.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# При PUSH_IMAGE=false (PR-сборки) логин не нужен — образы остаются локальными
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+    echo "PUSH_IMAGE != true — пропускаем docker login"
+    return 0
+fi
+
 # Проверка наличия необходимых переменных среды
 if [[ -z "$DOCKER_REGISTRY_URL" || -z "$DOCKER_LOGIN" || -z "$DOCKER_PASSWORD" ]]; then
     echo "Ошибка: Необходимо установить переменные среды DOCKER_REGISTRY_URL, DOCKER_LOGIN и DOCKER_PASSWORD."

--- a/src/build-edt-ripper.sh
+++ b/src/build-edt-ripper.sh
@@ -18,15 +18,22 @@ then
     docker system prune -af
 fi
 
-last_arg=("${PROJECT_ROOT}")
+last_arg="${PROJECT_ROOT}"
 if [[ ${NO_CACHE:-} = "true" ]] ; then
-	last_arg=("--no-cache" "${PROJECT_ROOT}")
+	last_arg="--no-cache ${PROJECT_ROOT}"
+fi
+
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
 fi
 
 edt_ripper_version="latest"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg EDT_RIPPER_VERSION="${edt_ripper_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-edt-ripper.sh
+++ b/src/build-edt-ripper.sh
@@ -37,15 +37,18 @@ docker build \
 if ./tests/test-edt-ripper.sh; then
     container_version=$(docker run --rm  "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/edt-ripper:${edt_ripper_version}" --version | tail -n1)
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/edt-ripper:${edt_ripper_version}"
 
         docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/edt-ripper:${edt_ripper_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/edt-ripper:${container_version}"
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/edt-ripper:${container_version}"
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"

--- a/src/build-gitrules.sh
+++ b/src/build-gitrules.sh
@@ -23,10 +23,17 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 gitrules_version="latest"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg GITRULES_VERSION="${gitrules_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-gitrules.sh
+++ b/src/build-gitrules.sh
@@ -37,15 +37,18 @@ docker build \
 if ./tests/test-gitrules.sh; then
     container_version=$(docker run --rm  "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/gitrules:${gitrules_version}" --version | tail -n1)
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/gitrules:${gitrules_version}"
 
         docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/gitrules:${gitrules_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/gitrules:${container_version}"
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/gitrules:${container_version}"
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"

--- a/src/build-onec-installer-downloader.sh
+++ b/src/build-onec-installer-downloader.sh
@@ -36,10 +36,14 @@ docker build \
     ${last_arg}
 
 if ${SCRIPT_DIR}/../tests/test-onec-installer-downloader.sh; then  
-    docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:${onec_installer_downloader_version}"
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
+        docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:${onec_installer_downloader_version}"
 
-    docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:${onec_installer_downloader_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:latest"
-    docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:latest"
+        docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:${onec_installer_downloader_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:latest"
+        docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/${image_name}:latest"
+    else
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
+    fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"
 else

--- a/src/build-onec-installer-downloader.sh
+++ b/src/build-onec-installer-downloader.sh
@@ -23,11 +23,18 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 onec_installer_downloader_version="${ONEC_INSTALLER_DOWNLOADER_VERSION}"
 image_name=onec-installer-downloader
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg ONEC_INSTALLER_DOWNLOADER_VERSION="${onec_installer_downloader_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-oscript.sh
+++ b/src/build-oscript.sh
@@ -35,7 +35,12 @@ docker build \
 if ./tests/test-oscript.sh; then
     container_version=$(docker run --rm  "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/oscript:${oscript_version}" -v | head -n1 | awk '{print $NF}')
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/oscript:${oscript_version}"
 
         container_version="$(echo "$container_version" | sed 's/+/_/g')"
@@ -52,10 +57,8 @@ if ./tests/test-oscript.sh; then
                 exit 1
             fi
         fi
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"
 else

--- a/src/build-oscript.sh
+++ b/src/build-oscript.sh
@@ -23,10 +23,24 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 oscript_version="${OSCRIPT_VERSION}"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg OSCRIPT_VERSION="${oscript_version}" \
     -t "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/oscript:${oscript_version}" \
     -f "${SCRIPT_DIR}/oscript/Dockerfile" \

--- a/src/build-stebi.sh
+++ b/src/build-stebi.sh
@@ -37,15 +37,18 @@ docker build \
 if ./tests/test-stebi.sh; then
     container_version=$(docker run --rm  "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/stebi:${stebi_version}" --version | tail -n1)
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/stebi:${stebi_version}"
 
         docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/stebi:${stebi_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/stebi:${container_version}"
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/stebi:${container_version}"
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"

--- a/src/build-stebi.sh
+++ b/src/build-stebi.sh
@@ -23,10 +23,17 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 stebi_version="latest"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg STEBI_VERSION="${stebi_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-winow.sh
+++ b/src/build-winow.sh
@@ -23,10 +23,17 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 winow_version="latest"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg WINOW_VERSION="${winow_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-winow.sh
+++ b/src/build-winow.sh
@@ -38,15 +38,18 @@ if ./tests/test-winow.sh; then
     opm_output=$(docker run --rm --entrypoint "opm" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/winow:${winow_version}" ls)
     container_version=$(echo "$opm_output" | awk -F '|' '/^winow[[:space:]]+\|/ {gsub(/ /, "", $2); print $2}')
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/winow:${winow_version}"
 
         docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/winow:${winow_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/winow:${container_version}"
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/winow:${container_version}"
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"

--- a/src/build-yard.sh
+++ b/src/build-yard.sh
@@ -23,10 +23,17 @@ if [[ ${NO_CACHE:-} = "true" ]] ; then
 	last_arg="--no-cache ${PROJECT_ROOT}"
 fi
 
+# В CI (PUSH_IMAGE=false) база уже подготовлена локально — --pull заставил бы BuildKit
+# игнорировать локальный образ и тянуть из registry
+pull_arg="--pull"
+if [[ "${PUSH_IMAGE:-true}" != "true" ]]; then
+	pull_arg=""
+fi
+
 yard_version="latest"
 
 docker build \
-    --pull \
+    ${pull_arg} \
     --build-arg YARD_VERSION="${yard_version}" \
     --build-arg DOCKER_REGISTRY_URL="${DOCKER_REGISTRY_URL}" \
     --build-arg DOCKER_LOGIN="${DOCKER_LOGIN}" \

--- a/src/build-yard.sh
+++ b/src/build-yard.sh
@@ -37,15 +37,18 @@ docker build \
 if ./tests/test-yard.sh; then
     container_version=$(docker run --rm  "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/yard:${yard_version}" --version | tail -n1)
 
-    if [[ -n "${container_version}" ]]; then
+    if [[ -z "${container_version}" ]]; then
+        log_failure "Не удалось получить версию из контейнера"
+        exit 1
+    fi
+
+    if [[ "${PUSH_IMAGE:-true}" == "true" ]]; then
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/yard:${yard_version}"
 
         docker tag "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/yard:${yard_version}" "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/yard:${container_version}"
         docker push "${DOCKER_REGISTRY_URL}/${DOCKER_LOGIN}/yard:${container_version}"
-
     else
-        log_failure "Не удалось получить версию из контейнера"
-        exit 1
+        echo "PUSH_IMAGE != true — push пропущен (теги не создаём)"
     fi
 
     source "${SCRIPT_DIR}/../scripts/cleanup.sh"


### PR DESCRIPTION
## Summary

Реализация #32 — CI-проверка сборки в каждом PR. Собираются и тестируются только образы, чьи файлы изменились, без пуша в registry и без секретов.

## Изменения

**Workflow `.github/workflows/ci.yml`:**
- `detect`: `dorny/paths-filter` → матрица образов по изменённым файлам
- `prepare-base`: база oscript собирается из PR-кода (если менялась) или pull+retag из Hub; yard-база аналогично для onec-installer-downloader
- `build`: матричная сборка + тесты, `PUSH_IMAGE=false`

**Матрица триггеров:**
| Файлы | Образы |
|---|---|
| `src/oscript/**` | все (регрессия downstream) |
| `src/<img>/**` + парные build/test | только <img> |
| `scripts/**`, `tools/**`, `ci.yml` | все |
| `README.md`, `src/tag-*.sh` | ничего |

**Build-скрипты:** поддержка `PUSH_IMAGE=false` (гард логина, пушей, `--pull`, logout). Дефолт `true` — релизный путь не тронут. Заодно пофикшен `unbound DOCKER_REGISTRY_URL` в cleanup.sh.

## Тест

Локальный smoke-тест `PUSH_IMAGE=false` на gitrules: сборка с локальной базы + тест зелёный + push пропущен. Этот PR сам триггерит CI (в диффе ci.yml → полный прогон 7 образов).

Closes #32