### PR TITLE
chore: расширить .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
+.git
+.github
+README.md
+tests
+tools
+scripts
 .env


### PR DESCRIPTION
## Что

Закрывает #27.

Расширил `.dockerignore` — теперь из контекста сборки исключаются:

- `.git/` — вся история коммитов
- `.github/`
- `README.md` (28 KB)
- `tests/`
- `tools/`
- `scripts/`
- `.env` (как и раньше)

## Почему безопасно

Контекст сборки — корень репо (`docker build ${PROJECT_ROOT}`). Проверил все 7 Dockerfile'ов: `COPY`/`ADD` встречаются только в двух, и обе ссылаются на файлы внутри `src/` (`src/onec-installer-downloader/downloader.sh`, `src/winow/entrypoint.sh`). Скрипты из `scripts/`/`tools/` (`load_env.sh`, `docker_login.sh`, `assert.sh`) подключаются на хосте через `source`, а не копируются в образ — исключение их из контекста ни на что не влияет.

Бонус: меньше данных в контексте → быстрее сборка и меньше инвалидаций кэша слоёв.

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Оптимизирован Docker-контекст: исключены служебные каталоги, тесты, скрипты и документация.
  * Файл `.env` по-прежнему исключён из Docker-контекста.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->